### PR TITLE
Fix culling particle with first frame

### DIFF
--- a/src/main/java/dev/tildejustin/xrayfix/ParticleCullingProvider.java
+++ b/src/main/java/dev/tildejustin/xrayfix/ParticleCullingProvider.java
@@ -2,7 +2,7 @@ package dev.tildejustin.xrayfix;
 
 public interface ParticleCullingProvider {
 
-    boolean xray_fix$shouldCull();
+    Boolean xray_fix$shouldCull();
 
     void xray_fix$setCull(boolean cull);
 

--- a/src/main/java/dev/tildejustin/xrayfix/mixin/ParticleManagerMixin.java
+++ b/src/main/java/dev/tildejustin/xrayfix/mixin/ParticleManagerMixin.java
@@ -18,9 +18,11 @@ public class ParticleManagerMixin {
     @WrapWithCondition(method = "renderParticles", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/particle/Particle;buildGeometry(Lnet/minecraft/client/render/VertexConsumer;Lnet/minecraft/client/render/Camera;F)V"))
     public boolean onRenderParticle(Particle instance, VertexConsumer vertexConsumer, Camera camera, float v) {
         Boolean cull = ((ParticleCullingProvider) instance).xray_fix$shouldCull();
-        if (cull == null) ((ParticleCullingProvider) instance).xray_fix$setCull(ParticleManagerHelper.shouldCull(instance));
-        else return !cull;
-        return !((ParticleCullingProvider) instance).xray_fix$shouldCull();
+        if (cull == null) {
+            cull = ParticleManagerHelper.shouldCull(instance);
+            ((ParticleCullingProvider) instance).xray_fix$setCull(cull);
+        }
+        return !cull;
     }
 
     @Inject(method = "tickParticle", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/particle/Particle;tick()V", shift = At.Shift.AFTER))

--- a/src/main/java/dev/tildejustin/xrayfix/mixin/ParticleManagerMixin.java
+++ b/src/main/java/dev/tildejustin/xrayfix/mixin/ParticleManagerMixin.java
@@ -17,6 +17,9 @@ public class ParticleManagerMixin {
 
     @WrapWithCondition(method = "renderParticles", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/particle/Particle;buildGeometry(Lnet/minecraft/client/render/VertexConsumer;Lnet/minecraft/client/render/Camera;F)V"))
     public boolean onRenderParticle(Particle instance, VertexConsumer vertexConsumer, Camera camera, float v) {
+        Boolean cull = ((ParticleCullingProvider) instance).xray_fix$shouldCull();
+        if (cull == null) ((ParticleCullingProvider) instance).xray_fix$setCull(ParticleManagerHelper.shouldCull(instance));
+        else return !cull;
         return !((ParticleCullingProvider) instance).xray_fix$shouldCull();
     }
 

--- a/src/main/java/dev/tildejustin/xrayfix/mixin/ParticleMixin.java
+++ b/src/main/java/dev/tildejustin/xrayfix/mixin/ParticleMixin.java
@@ -9,10 +9,10 @@ import org.spongepowered.asm.mixin.Unique;
 public class ParticleMixin implements ParticleCullingProvider {
 
     @Unique
-    private boolean cull = true;
+    private Boolean cull = null;
 
     @Override
-    public boolean xray_fix$shouldCull() {
+    public Boolean xray_fix$shouldCull() {
         return this.cull;
     }
 


### PR DESCRIPTION
It was increadibly hard to notice, but set initial value of `cull` to `true` was wrong decision. now it is use Nullable boolean and check culling when it is `null` (as initial value)